### PR TITLE
Add pregenerated CRD manifests

### DIFF
--- a/k3s.cattle.io/v1/types.go
+++ b/k3s.cattle.io/v1/types.go
@@ -7,6 +7,8 @@ import (
 
 // +genclient
 // +genclient:noStatus
+// +kubebuilder:printcolumn:name="Source",type=string,JSONPath=`.spec.source`
+// +kubebuilder:printcolumn:name="Checksum",type=string,JSONPath=`.spec.checksum`
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Addon is used to track application of a manifest file on disk. It mostly exists so that the wrangler DesiredSet
@@ -29,6 +31,11 @@ type AddonSpec struct {
 
 // +genclient
 // +genclient:nonNamespaced
+// +kubebuilder:printcolumn:name="SnapshotName",type=string,JSONPath=`.spec.snapshotName`
+// +kubebuilder:printcolumn:name="Node",type=string,JSONPath=`.spec.nodeName`
+// +kubebuilder:printcolumn:name="Location",type=string,JSONPath=`.spec.location`
+// +kubebuilder:printcolumn:name="Size",type=string,JSONPath=`.spec.size`
+// +kubebuilder:printcolumn:name="CreationTime",type=date,JSONPath=`.spec.creationTime`
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ETCDSnapshot tracks a point-in-time snapshot of the etcd datastore.

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 //go:generate go run pkg/codegen/cleanup/main.go
-//go:generate rm -rf pkg/generated
+//go:generate rm -rf pkg/generated pkg/crds/yaml/generated
 //go:generate go run pkg/codegen/main.go
+//go:generate controller-gen crd:generateEmbeddedObjectMeta=true paths=./k3s.cattle.io/... output:crd:dir=./pkg/crds/yaml/generated
 
 package main
 

--- a/pkg/crds/crds.go
+++ b/pkg/crds/crds.go
@@ -1,0 +1,84 @@
+package crds
+
+import (
+	"embed"
+	"fmt"
+	"path/filepath"
+
+	"github.com/rancher/wrangler/v3/pkg/yaml"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+const (
+	baseDir = "."
+	crdKind = "CustomResourceDefinition"
+)
+
+var (
+	//go:embed yaml
+	crdFS embed.FS
+
+	errDuplicate = fmt.Errorf("duplicate CRD")
+)
+
+func List() ([]*apiextv1.CustomResourceDefinition, error) {
+	crdMap, err := crdsFromDir(baseDir)
+	if err != nil {
+		return nil, err
+	}
+	crds := make([]*apiextv1.CustomResourceDefinition, 0, len(crdMap))
+	for _, crd := range crdMap {
+		crds = append(crds, crd)
+	}
+	return crds, nil
+}
+
+// crdsFromDir recursively traverses the embedded yaml directory and find all CRD yamls.
+// cribbed from https://github.com/rancher/rancher/blob/v2.11.2/pkg/crds/crds.go
+func crdsFromDir(dirName string) (map[string]*apiextv1.CustomResourceDefinition, error) {
+	// read all entries in the embedded directory
+	crdFiles, err := crdFS.ReadDir(dirName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read embedded dir '%s': %w", dirName, err)
+	}
+
+	allCRDs := map[string]*apiextv1.CustomResourceDefinition{}
+	for _, dirEntry := range crdFiles {
+		fullPath := filepath.Join(dirName, dirEntry.Name())
+		if dirEntry.IsDir() {
+			// if the entry is the dir recurse into that folder to get all crds
+			subCRDs, err := crdsFromDir(fullPath)
+			if err != nil {
+				return nil, err
+			}
+			for k, v := range subCRDs {
+				if _, ok := allCRDs[k]; ok {
+					return nil, fmt.Errorf("%w for '%s", errDuplicate, k)
+				}
+				allCRDs[k] = v
+			}
+			continue
+		}
+
+		// read the file and convert it to a crd object
+		file, err := crdFS.Open(fullPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open embedded file '%s': %w", fullPath, err)
+		}
+		crdObjs, err := yaml.UnmarshalWithJSONDecoder[*apiextv1.CustomResourceDefinition](file)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert embedded file '%s' to yaml: %w", fullPath, err)
+		}
+		for _, crdObj := range crdObjs {
+			if crdObj.Kind != crdKind {
+				// if the yaml is not a CRD return an error
+				return nil, fmt.Errorf("decoded object is not '%s' instead found Kind='%s'", crdKind, crdObj.Kind)
+			}
+			if _, ok := allCRDs[crdObj.Name]; ok {
+				return nil, fmt.Errorf("%w for '%s", errDuplicate, crdObj.Name)
+			}
+			allCRDs[crdObj.Name] = crdObj
+		}
+	}
+	return allCRDs, nil
+}

--- a/pkg/crds/yaml/generated/k3s.cattle.io_addons.yaml
+++ b/pkg/crds/yaml/generated/k3s.cattle.io_addons.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: addons.k3s.cattle.io
+spec:
+  group: k3s.cattle.io
+  names:
+    kind: Addon
+    listKind: AddonList
+    plural: addons
+    singular: addon
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.source
+      name: Source
+      type: string
+    - jsonPath: .spec.checksum
+      name: Checksum
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          Addon is used to track application of a manifest file on disk. It mostly exists so that the wrangler DesiredSet
+          Apply controller has an object to track as the owner, and ensure that all created resources are tracked when the
+          manifest is modified or removed.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec provides information about the on-disk manifest backing
+              this resource.
+            properties:
+              checksum:
+                description: Checksum is the SHA256 checksum of the most recently
+                  successfully applied manifest file.
+                type: string
+              source:
+                description: Source is the Path on disk to the manifest file that
+                  this Addon tracks.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/pkg/crds/yaml/generated/k3s.cattle.io_etcdsnapshotfiles.yaml
+++ b/pkg/crds/yaml/generated/k3s.cattle.io_etcdsnapshotfiles.yaml
@@ -1,0 +1,162 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: etcdsnapshotfiles.k3s.cattle.io
+spec:
+  group: k3s.cattle.io
+  names:
+    kind: ETCDSnapshotFile
+    listKind: ETCDSnapshotFileList
+    plural: etcdsnapshotfiles
+    singular: etcdsnapshotfile
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.snapshotName
+      name: SnapshotName
+      type: string
+    - jsonPath: .spec.nodeName
+      name: Node
+      type: string
+    - jsonPath: .spec.location
+      name: Location
+      type: string
+    - jsonPath: .spec.size
+      name: Size
+      type: string
+    - jsonPath: .spec.creationTime
+      name: CreationTime
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: ETCDSnapshot tracks a point-in-time snapshot of the etcd datastore.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines properties of an etcd snapshot file
+            properties:
+              location:
+                description: Location is the absolute file:// or s3:// URI address
+                  of the snapshot.
+                type: string
+              metadata:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Metadata contains point-in-time snapshot of the contents of the
+                  k3s-etcd-snapshot-extra-metadata ConfigMap's data field, at the time the
+                  snapshot was taken. This is intended to contain data about cluster state
+                  that may be important for an external system to have available when restoring
+                  the snapshot.
+                type: object
+              nodeName:
+                description: NodeName contains the name of the node that took the
+                  snapshot.
+                type: string
+              s3:
+                description: |-
+                  S3 contains extra metadata about the S3 storage system holding the
+                  snapshot. This is guaranteed to be set for all snapshots uploaded to S3.
+                  If not specified, the snapshot was not uploaded to S3.
+                properties:
+                  bucket:
+                    description: Bucket is the bucket holding the snapshot
+                    type: string
+                  bucketLookup:
+                    description: BucketLookup is the bucket lookup type, one of 'auto',
+                      'dns', 'path'. Default if empty is 'auto'.
+                    type: string
+                  endpoint:
+                    description: Endpoint is the host or host:port of the S3 service
+                    type: string
+                  endpointCA:
+                    description: EndpointCA is the path on disk to the S3 service's
+                      trusted CA list. Leave empty to use the OS CA bundle.
+                    type: string
+                  insecure:
+                    description: Insecure is true if the S3 service uses HTTP instead
+                      of HTTPS
+                    type: boolean
+                  prefix:
+                    description: Prefix is the prefix in which the snapshot file is
+                      stored.
+                    type: string
+                  region:
+                    description: Region is the region of the S3 service
+                    type: string
+                  skipSSLVerify:
+                    description: SkipSSLVerify is true if TLS certificate verification
+                      is disabled
+                    type: boolean
+                type: object
+              snapshotName:
+                description: |-
+                  SnapshotName contains the base name of the snapshot file. CLI actions that act
+                  on snapshots stored locally or within a pre-configured S3 bucket and
+                  prefix usually take the snapshot name as their argument.
+                type: string
+            required:
+            - location
+            - nodeName
+            - snapshotName
+            type: object
+          status:
+            description: Status represents current information about a snapshot.
+            properties:
+              creationTime:
+                description: CreationTime is the timestamp when the snapshot was taken
+                  by etcd.
+                format: date-time
+                type: string
+              error:
+                description: |-
+                  Error is the last observed error during snapshot creation, if any.
+                  If the snapshot is retried, this field will be cleared on success.
+                properties:
+                  message:
+                    description: |-
+                      Message is a string detailing the encountered error during snapshot creation if specified.
+                      NOTE: message may be logged, and it should not contain sensitive information.
+                    type: string
+                  time:
+                    description: Time is the timestamp when the error was encountered.
+                    format: date-time
+                    type: string
+                type: object
+              readyToUse:
+                description: ReadyToUse indicates that the snapshot is available to
+                  be restored.
+                type: boolean
+              size:
+                anyOf:
+                - type: integer
+                - type: string
+                description: Size is the size of the snapshot file, in bytes. If not
+                  specified, the snapshot failed.
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}


### PR DESCRIPTION
Will replace the use of wrangler CRD helpers at
https://github.com/k3s-io/k3s/blob/338b9cc923dbf93b320a8420e5b1355556671efb/pkg/crd/crds.go#L12-L22

Use of kubebuilder for CRD generation adds field descriptions so that the crds are self-documenting in `kubectl explain`