### PR TITLE
Fix etcdsnapshotfile scope

### DIFF
--- a/k3s.cattle.io/v1/types.go
+++ b/k3s.cattle.io/v1/types.go
@@ -31,6 +31,7 @@ type AddonSpec struct {
 
 // +genclient
 // +genclient:nonNamespaced
+// +kubebuilder:resource:scope=Cluster
 // +kubebuilder:printcolumn:name="SnapshotName",type=string,JSONPath=`.spec.snapshotName`
 // +kubebuilder:printcolumn:name="Node",type=string,JSONPath=`.spec.nodeName`
 // +kubebuilder:printcolumn:name="Location",type=string,JSONPath=`.spec.location`

--- a/pkg/crds/yaml/generated/k3s.cattle.io_etcdsnapshotfiles.yaml
+++ b/pkg/crds/yaml/generated/k3s.cattle.io_etcdsnapshotfiles.yaml
@@ -12,7 +12,7 @@ spec:
     listKind: ETCDSnapshotFileList
     plural: etcdsnapshotfiles
     singular: etcdsnapshotfile
-  scope: Namespaced
+  scope: Cluster
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.snapshotName


### PR DESCRIPTION
`genclient:nonNamespaced` does not handle this as it did for the wrangler helpers, we must explicitly set the scope